### PR TITLE
fix: add --local flag to dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest --verbose",
-    "dev": "wrangler dev src/index.ts",
+    "dev": "wrangler dev src/index.ts --local",
     "deploy": "wrangler publish src/index.ts"
   },
   "license": "MIT",


### PR DESCRIPTION
### tl;dr

- [x] Adds `--local` flag to dev command

### Description

I was trying to run this minimal example but kept receiving the following error:

```bash
{
    text: 'Received a bad response from the API',
    notes: [ { text: 'workers.api.error.subdomain_required [code: 10063]' } ],
    location: undefined,
    kind: 'error',
    code: 10063
  }
```

After adding the `--local` flag, which is defined as `Run on my machine` on the CLI, everything worked!